### PR TITLE
fix: compile err because wrong path of remoc

### DIFF
--- a/crates/gmw/Cargo.toml
+++ b/crates/gmw/Cargo.toml
@@ -41,7 +41,7 @@ rangemap = "1.0.3"
 once_cell = "1.13.1"
 gmw-macros = {path = "../gmw-macros"}
 mpc-channel = {path = "../mpc-channel"}
-remoc = { path = "../../../remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
+remoc = { path = "../../libs/remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
 zappot = {path = "../zappot", features = ["silent_ot"]}
 typemap = "0.3.3"
 indexmap = "1.9.1"

--- a/crates/mpc-channel/Cargo.toml
+++ b/crates/mpc-channel/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.21.1", features = ["macros", "net"]}
 tokio-serde = { version = "0.8.0", features = ["bincode"]}
 tokio-util = { version = "0.7.3", features = ["codec"]}
 tracing = "0.1.36"
-remoc = { path = "../../../remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
+remoc = { path = "../../libs/remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
 mpc-channel-macros = {path = "../mpc-channel-macros"}
 
 [dev-dependencies]

--- a/crates/zappot/Cargo.toml
+++ b/crates/zappot/Cargo.toml
@@ -40,7 +40,7 @@ tokio-util = { version = "0.7.3", features = ["codec"]}
 ndarray = { version = "0.15.4", features = ["rayon"]}
 thiserror = "1.0.31"
 tracing = "0.1.35"
-remoc = { path = "../../../remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
+remoc = { path = "../../libs/remoc/remoc", default-features = false, features = ["rch", "codec-bincode"]}
 libote-sys = { path = "../../libs/libote-sys", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
wrong remoc path. maybe typo.

compile passed at rustc/cargo 1.74